### PR TITLE
Module import failed with ImportError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'Operating System :: POSIX :: Linux'
     ],
     install_requires=[
-        'xmltodict'
+        'xmltodict', 'utils'
     ],
     keywords=utils.__keywords__,
     include_package_data=True,


### PR DESCRIPTION
Fix Issue: ImportError: No module named 'utils'